### PR TITLE
Rewrite 'index' link in base template

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -13,7 +13,7 @@
         <div class="govuk-header__logo">
             <a href="#" class="govuk-header__link govuk-header__link--homepage">
                 <span class="govuk-header__logotype">
-                    <a href='index' class='govuk-header__link'>
+                    <a href="{{ url_for('index') }}" class='govuk-header__link'>
                       <span class="govuk-header__logotype-text">
                       Masterclasses 
                       </span>


### PR DESCRIPTION
I noticed that when trying to click the 'Masterclasses' link in the header from the view at masterclass/<masterclass_id>, there was an error. I've fixed this error by changing this link to 'url_for', which means Flask will look for the route labelled 'index' rather than just appending 'index' to the current path.

Before:
![Screenshot 2019-11-19 at 14 27 44](https://user-images.githubusercontent.com/3410350/69154914-c571ba80-0ad8-11ea-9333-718c8feca532.png)

After:

There isn't really anything to show here, it just goes back to the homepage 😸